### PR TITLE
New lockdown command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ typings/
 
 # Config file - CONTAINS TOKEN!
 config.json
+
+# Data folder for enmaps
+data

--- a/app.js
+++ b/app.js
@@ -42,6 +42,7 @@ client.registry
 	.registerCommandsIn(path.join(__dirname, "commands"));
 
 client.softbanned = new Enmap({provider: softbanPersistent});
+client.lockedChannels = new Enmap();
 
 client.on("ready", () => {
 	console.log("Logged in!");

--- a/commands/moderation/liftlockdown.js
+++ b/commands/moderation/liftlockdown.js
@@ -1,0 +1,60 @@
+/*
+pedro-discordjs-bot (c) 2017 Valentijn "Ev1l0rd"
+A moderation bot for the freeShop server
+Unless explicitly acquired and licensed from Licensor under another
+license, the contents of this file are subject to the Reciprocal Public
+License ("RPL") Version 1.5, or subsequent versions as allowed by the RPL,
+	and You may not copy or use this file in either source code or executable
+form, except in compliance with the terms and conditions of the RPL.
+
+	All software distributed under the RPL is provided strictly on an "AS
+IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, AND
+LICENSOR HEREBY DISCLAIMS ALL SUCH WARRANTIES, INCLUDING WITHOUT
+LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, QUIET ENJOYMENT, OR NON-INFRINGEMENT. See the RPL for specific
+	language governing rights and limitations under the RPL.
+*/
+//Creates the rules post
+let config = require("../../config.json");
+let approvedConfig = config.approvedID;
+let modRole = config.modID;
+let adminRole = config.adminID;
+let logChannelConfig = config.logChannel;
+const {Command} = require("discord.js-commando");
+
+module.exports = class createRules extends Command {
+	constructor(client) {
+		super(client, {
+			name: "liftlockdown",
+			group: "moderation",
+			memberName: "liftlockdown",
+			description: "Lifts a lockdown on a channel.",
+			examples: ["lockdown"],
+			guildOnly: true
+		});
+	}
+
+	hasPermission(msg) {
+		if (msg.member.roles.has(modRole) || msg.member.roles.has(adminRole)) {
+			return true;
+		} else {
+			return "Only people marked as Supervisor or Administrator can run this command.";
+		}
+	}
+
+	async run(msg) {
+		let channelToLock = msg.channel;
+		let logChannel = this.client.channels.get(logChannelConfig);
+		let approvedRole = msg.guild.roles.get(approvedConfig);
+
+		channelToLock.overwritePermissions(approvedRole, {
+			SEND_MESSAGES: true
+		}, "Channel Lockdown lifted.");
+
+		if (this.client.lockedChannels.get(channelToLock.id)) {
+			logChannel.send("🔓 User " + msg.author.toString() + "lifted a lockdown in channel" + msg.channel.toString() + ".");
+		}
+		await this.client.lockedChannels.set(channelToLock.id, false);
+		return msg.say("Channel lockdown has been lifted.");
+	}
+};

--- a/commands/moderation/lockdown.js
+++ b/commands/moderation/lockdown.js
@@ -1,0 +1,62 @@
+/*
+pedro-discordjs-bot (c) 2017 Valentijn "Ev1l0rd"
+A moderation bot for the freeShop server
+Unless explicitly acquired and licensed from Licensor under another
+license, the contents of this file are subject to the Reciprocal Public
+License ("RPL") Version 1.5, or subsequent versions as allowed by the RPL,
+	and You may not copy or use this file in either source code or executable
+form, except in compliance with the terms and conditions of the RPL.
+
+	All software distributed under the RPL is provided strictly on an "AS
+IS" basis, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, AND
+LICENSOR HEREBY DISCLAIMS ALL SUCH WARRANTIES, INCLUDING WITHOUT
+LIMITATION, ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, QUIET ENJOYMENT, OR NON-INFRINGEMENT. See the RPL for specific
+	language governing rights and limitations under the RPL.
+*/
+//Locks down a channel
+let config = require("../../config.json");
+let modRole = config.modID;
+let adminRole = config.adminID;
+let approvedConfig = config.approvedID;
+let logChannelConfig = config.logChannel;
+const {Command} = require("discord.js-commando");
+
+module.exports = class createRules extends Command {
+	constructor(client) {
+		super(client, {
+			name: "lockdown",
+			group: "moderation",
+			memberName: "lockdown",
+			description: "Locks down a channel. Only roles defined as Moderator or Administator in config.json can speak. Use _liftlockdown_ to remove the lockdown.",
+			examples: ["lockdown"],
+			guildOnly: true
+		});
+	}
+
+	hasPermission(msg) {
+		if (msg.member.roles.has(modRole) || msg.member.roles.has(adminRole)) {
+			return true;
+		} else {
+			return "Only people marked as Supervisor or Administrator can run this command.";
+		}
+	}
+
+	async run(msg) {
+		let channelToLock = msg.channel;
+		let logChannel = this.client.channels.get(logChannelConfig);
+		let approvedRole = msg.guild.roles.get(approvedConfig);
+
+
+		channelToLock.overwritePermissions(approvedRole, {
+			SEND_MESSAGES: false
+		}, "Channel Lockdown initiated.");
+
+		if (!this.client.lockedChannels.get(channelToLock.id)) {
+			logChannel.send("🔒 User " + msg.author.toString() + "initiated a lockdown in channel" + msg.channel.toString() + ".");
+		}
+
+		await this.client.lockedChannels.set(channelToLock.id, true);
+		return msg.say("Channel lockdown initiated");
+	}
+};

--- a/config.json.example
+++ b/config.json.example
@@ -7,6 +7,7 @@
   "modID": "", // Normal moderator Role.
   "adminID": "", // Supervisor/Admin Role.
   "ownerID": "", // Your ID
+  "approvedID": "", // Role for approved members. If you dont use an approved member system, just set this to the RoleID for everyone.
 
   "offTopicChannel": "", //Offtopic Channel ID
   "logChannel": "" //Log Channel ID. The various more "traditional" mod actions of Pedro are logged here.


### PR DESCRIPTION
Couple of things about it:

- `lockdown` locks down a channel
- `liftlockdown` lifts the lockdown on a channel

Current lockdowns are stored in a non-persistant enmap. If any of the lockdown commands is ran in an already locked down channel, the command will run as normal but will not be logged.

Also added the data folder to gitignore.

This commit resolves #6  